### PR TITLE
Allow graceful exiting when empty queue is raised

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,6 @@ universal = 1
 
 [flake8]
 exclude = docs
-max-line-length = 88
+max-line-length = 100
 extend-ignore = E203, W503
 

--- a/tests/test_message_queue.py
+++ b/tests/test_message_queue.py
@@ -9,7 +9,7 @@ from unittest import mock
 
 from kafka.admin import KafkaAdminClient
 
-from poppy.engine import KafkaEngine
+from poppy.engine import EmptyQueueException, KafkaEngine
 from poppy.messsaging import Queue
 
 from .utils import (
@@ -265,8 +265,8 @@ class TestQueueKafkaUnit(unittest.TestCase):
 
         self.config["RAISE_ON_EMPTY_DEQUEUE"] = True
         tq = Queue(self.config)
-        tq.engine.consumer.__next__.side_effect = StopIteration()
-        with self.assertRaises(StopIteration):
+        tq.engine.consumer.__next__.side_effect = EmptyQueueException()
+        with self.assertRaises(EmptyQueueException):
             tq.dequeue()
 
 


### PR DESCRIPTION
* Dequeue up to `--batch` messages
* If empty queue is reached exit with status code 100
* Add a custom empty queue exception to be consistent between different backends